### PR TITLE
Add freertos/ prefix to header includes

### DIFF
--- a/examples/device/cdc_msc_freertos/src/main.c
+++ b/examples/device/cdc_msc_freertos/src/main.c
@@ -28,10 +28,10 @@
 #include <string.h>
 
 #include "FreeRTOS.h"
-#include "task.h"
-#include "timers.h"
-#include "queue.h"
-#include "semphr.h"
+#include "freertos/task.h"
+#include "freertos/timers.h"
+#include "freertos/queue.h"
+#include "freertos/semphr.h"
 
 #include "bsp/board.h"
 #include "tusb.h"

--- a/examples/device/hid_composite_freertos/src/main.c
+++ b/examples/device/hid_composite_freertos/src/main.c
@@ -28,10 +28,10 @@
 #include <string.h>
 
 #include "FreeRTOS.h"
-#include "task.h"
-#include "timers.h"
-#include "queue.h"
-#include "semphr.h"
+#include "freertos/task.h"
+#include "freertos/timers.h"
+#include "freertos/queue.h"
+#include "freertos/semphr.h"
 
 #include "bsp/board.h"
 #include "tusb.h"

--- a/src/osal/osal_freertos.h
+++ b/src/osal/osal_freertos.h
@@ -29,9 +29,9 @@
 
 // FreeRTOS Headers
 #include "FreeRTOS.h"
-#include "semphr.h"
-#include "queue.h"
-#include "task.h"
+#include "freertos/semphr.h"
+#include "freertos/queue.h"
+#include "freertos/task.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This avoids conflicts with other, similarly named, header files.