### PR TITLE
class: add video device

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(srcs
     "src/class/msc/msc_device.c"
     "src/class/vendor/vendor_device.c"
     "src/class/audio/audio_device.c"
+    "src/class/video/video_device.c"
     "src/class/bth/bth_device.c"
     # NET class
     "src/class/net/ecm_rndis_device.c"


### PR DESCRIPTION
UVC Device works well on ESP32S2/S3 now, please consider adding the source file.

We have tested isochronous and bulk mode, both works well.
