### PR TITLE
fix(NCM): set default NCM mode is connect, add notify judgement

### DIFF
--- a/src/class/net/net_device.h
+++ b/src/class/net/net_device.h
@@ -77,12 +77,6 @@ bool tud_network_can_xmit(uint16_t size);
 // if network_can_xmit() returns true, network_xmit() can be called once
 void tud_network_xmit(void *ref, uint16_t arg);
 
-// indicate to network disconnect
-void tud_network_disconnect(void);
-
-// indicate to network connect
-void tud_network_connect(void);
-
 //--------------------------------------------------------------------+
 // Application Callbacks (WEAK is optional)
 //--------------------------------------------------------------------+
@@ -106,6 +100,12 @@ extern uint8_t tud_network_mac_address[6];
 
 // callback to client providing optional indication of internal state of network driver
 void tud_network_link_state_cb(bool state);
+
+// indicate to network disconnect, only work in NCM
+bool tud_network_disconnect(void);
+
+// indicate to network connect, only work in NCM
+bool tud_network_connect(void);
 
 //--------------------------------------------------------------------+
 // INTERNAL USBD-CLASS DRIVER API


### PR DESCRIPTION
1. Set default network state is connected, in case not actively call tud_network_connect
2. The application layer can get the call result

Upstream PR https://github.com/hathach/tinyusb/pull/2254
