### PR TITLE
TinyUSB release/0.15: ESP32P4 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,14 @@
 idf_build_get_property(target IDF_TARGET)
 
-set(tusb_family "esp32sx")
-
 if(target STREQUAL "esp32s3")
     set(tusb_mcu "OPT_MCU_ESP32S3")
+    set(tusb_family "esp32sx")
 elseif(target STREQUAL "esp32s2")
     set(tusb_mcu "OPT_MCU_ESP32S2")
+    set(tusb_family "esp32sx")
+elseif(target STREQUAL "esp32p4")
+    set(tusb_mcu "OPT_MCU_ESP32P4")
+    set(tusb_family "esp32px")
 endif()
 
 set(compile_options
@@ -54,7 +57,6 @@ idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS ${includes_public}
                        PRIV_INCLUDE_DIRS ${includes_private}
                        PRIV_REQUIRES esp_netif # required by rndis_reports.c: #include "netif/ethernet.h"
-                       REQUIRED_IDF_TARGETS esp32s2 esp32s3
                        )
 
 target_compile_options(${COMPONENT_LIB} PUBLIC ${compile_options})

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -7,3 +7,4 @@ dependencies:
 targets:
   - esp32s2
   - esp32s3
+  - esp32p4

--- a/src/common/tusb_mcu.h
+++ b/src/common/tusb_mcu.h
@@ -302,6 +302,10 @@
   #define TUP_USBIP_DWC2
   #define TUP_DCD_ENDPOINT_MAX    6
 
+#elif TU_CHECK_MCU(OPT_MCU_ESP32P4)
+  #define TUP_USBIP_DWC2
+  #define TUP_DCD_ENDPOINT_MAX    15
+
 //--------------------------------------------------------------------+
 // Dialog
 //--------------------------------------------------------------------+

--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -43,7 +43,7 @@
 
 #if defined(TUP_USBIP_DWC2_STM32)
   #include "dwc2_stm32.h"
-#elif TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3)
+#elif TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3, OPT_MCU_ESP32P4)
   #include "dwc2_esp32.h"
 #elif TU_CHECK_MCU(OPT_MCU_GD32VF103)
   #include "dwc2_gd32.h"

--- a/src/portable/synopsys/dwc2/dwc2_esp32.h
+++ b/src/portable/synopsys/dwc2/dwc2_esp32.h
@@ -33,37 +33,74 @@
 #endif
 
 #include "esp_intr_alloc.h"
-#include "soc/periph_defs.h"
-//#include "soc/usb_periph.h"
+#include "soc/interrupts.h"
 
-#define DWC2_REG_BASE       0x60080000UL
-#define DWC2_EP_MAX         6             // USB_OUT_EP_NUM. TODO ESP32Sx only has 5 tx fifo (5 endpoint IN)
+#if CFG_TUSB_MCU == OPT_MCU_ESP32P4
+  #define DWC2_PERIPH_COUNT    2
+  #define DWC2_HS_PERIPH_BASE  0x50000000UL
+  #define DWC2_FS_PERIPH_BASE  0x50040000UL
+  #define DWC2_HS_INTR_SOURCE  ETS_USB_OTG_ENDP_MULTI_PROC_INTR_SOURCE
+  #define DWC2_FS_INTR_SOURCE  ETS_USB_OTG11_CH0_INTR_SOURCE
+#elif TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3)
+  #define DWC2_PERIPH_COUNT    1
+  #define DWC2_FS_PERIPH_BASE  0x60080000UL
+  #define DWC2_FS_INTR_SOURCE  ETS_USB_INTR_SOURCE
+#else
+  #error "DWC2_REG_BASE not defined for current MCU"
+#endif
 
+#if DWC2_HS_PERIPH_BASE
+  #define DWC2_HS_EP_MAX       15             // USB_OUT_EP_NUM
+  #define DWC2_HS_EP_FIFO_SIZE 4096
+#endif
+
+#if DWC2_FS_PERIPH_BASE
+  #define DWC2_FS_EP_MAX       6             // USB_OUT_EP_NUM. TODO ESP32Sx only has 5 tx fifo (5 endpoint IN)
+  #define DWC2_FS_EP_FIFO_SIZE 1024
+#endif
+
+// OTG HS always has higher number of endpoints than FS
+// Declare the DWC2_EP_MAX as a higher number, because dcd_dwc2.c has a xfer_status
+// buffer, tied to the EP MAX value.
+// IMPORTANT: Be careful during usage of two USB periphs (HS and FS) at the same time with full EPs load.
+#ifdef USB_OTG_HS_PERIPH_BASE
+  #define DWC2_EP_MAX   DWC2_HS_EP_MAX
+#else
+  #define DWC2_EP_MAX   DWC2_FS_EP_MAX
+#endif
+
+// On ESP32 for consistency we associate
+// - Port0 to OTG_FS, and Port1 to OTG_HS
 static const dwc2_controller_t _dwc2_controller[] =
 {
-  { .reg_base = DWC2_REG_BASE, .irqnum = 0, .ep_count = DWC2_EP_MAX, .ep_fifo_size = 1024 }
+#ifdef DWC2_FS_PERIPH_BASE
+  { .reg_base = DWC2_FS_PERIPH_BASE, .irqnum = DWC2_FS_INTR_SOURCE, .ep_count = DWC2_FS_EP_MAX, .ep_fifo_size = DWC2_FS_EP_FIFO_SIZE },
+#endif
+
+#ifdef DWC2_HS_PERIPH_BASE
+  { .reg_base = DWC2_HS_PERIPH_BASE, .irqnum = DWC2_HS_INTR_SOURCE, .ep_count = DWC2_HS_EP_MAX, .ep_fifo_size = DWC2_HS_EP_FIFO_SIZE },
+#endif
 };
 
-static intr_handle_t usb_ih;
+static intr_handle_t usb_ih[DWC2_PERIPH_COUNT];
 
 static void dcd_int_handler_wrap(void* arg)
 {
-  (void) arg;
-  dcd_int_handler(0);
+  unsigned int rhport = (unsigned int) arg;
+  dcd_int_handler(rhport);
 }
 
 TU_ATTR_ALWAYS_INLINE
 static inline void dwc2_dcd_int_enable (uint8_t rhport)
 {
-  (void) rhport;
-  esp_intr_alloc(ETS_USB_INTR_SOURCE, ESP_INTR_FLAG_LOWMED, dcd_int_handler_wrap, NULL, &usb_ih);
+  unsigned int port = (unsigned int) rhport;
+  esp_intr_alloc(_dwc2_controller[rhport].irqnum, ESP_INTR_FLAG_LOWMED, dcd_int_handler_wrap, (void *) port, &usb_ih[rhport]);
 }
 
 TU_ATTR_ALWAYS_INLINE
 static inline void dwc2_dcd_int_disable (uint8_t rhport)
 {
-  (void) rhport;
-  esp_intr_free(usb_ih);
+  esp_intr_free(usb_ih[rhport]);
 }
 
 static inline void dwc2_remote_wakeup_delay(void)

--- a/src/tusb_option.h
+++ b/src/tusb_option.h
@@ -110,6 +110,7 @@
 // Espressif
 #define OPT_MCU_ESP32S2           900 ///< Espressif ESP32-S2
 #define OPT_MCU_ESP32S3           901 ///< Espressif ESP32-S3
+#define OPT_MCU_ESP32P4           902 ///< Espressif ESP32-P4
 
 // Dialog
 #define OPT_MCU_DA1469X          1000 ///< Dialog Semiconductor DA1469x


### PR DESCRIPTION
**TinyUSB v0.15.0~4**

ESP32P4 support

**Changes**
- Added `supported_mcu` variable and esp32p4 target to `CMakeList.txt`
- Added `OPT_MCU_ESP32P4`
- Added DWC2 periph description for `ESP32P4`.  For consistency we associate `Port0` to OTG1.1 USB PHY (FS), and `Port1` to OTG2.0 USB PHY (HS)
