### PR TITLE
fix(dcd_dwc2): Changed OTG Bvalid override configuration for ESP32

### DIFF
--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -521,8 +521,9 @@ void dcd_init (uint8_t rhport)
   // Force device mode
   dwc2->gusbcfg = (dwc2->gusbcfg & ~GUSBCFG_FHMOD) | GUSBCFG_FDMOD;
 
-  // Clear A override, force B Valid
-  dwc2->gotgctl = (dwc2->gotgctl & ~GOTGCTL_AVALOEN) | GOTGCTL_BVALOEN | GOTGCTL_BVALOVAL;
+  // No overrides
+  dwc2->gotgctl &= ~(GOTGCTL_BVALOEN | GOTGCTL_BVALOVAL | GOTGCTL_VBVALOVAL);
+
 
   // If USB host misbehaves during status portion of control xfer
   // (non zero-length packet), send STALL back and discard.


### PR DESCRIPTION
Closes https://github.com/espressif/esp-idf/issues/12360

**Changes**
- Disabled overriding Bvalid signal by software. 

**Additional context**
When tinyUSB driver installed with `self_powered` and `vbus_monitor_io` configuration, during `usb_phy_new()` initialization the IO multiplexer combining a GPIO input (value from `vbus_monitor_io`) with a peripheral signal `bvalid_io_num`. 

According to that configuration, after deasserting the VBUS (and GPIO input is low), Bvalid signal controlled by phy's `utmiotg_bvalid` signal and the session end detect flag appears in GOTGINT register, which in its own triggers the IRQ. 

During the IRQ handler in DCD, the `DCD_EVENT_UNPLUGGED` is triggered to inform the `usbd` layer about device disconnection from the Host.

UPD: 
1. Changes also verified without `self_powered` and `vbus_monitor_io` configuration. The working status does not affected. 
2. The changes doesn't keep the cleaning the Avalid overriding signal, which is applicable only for Host devices.

Test for the changes: https://github.com/espressif/esp-usb/pull/10