### PR TITLE
fix(dcd_dwc2): Reset opened EP counters on bus_reset event

### DIFF
--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -633,48 +633,52 @@ void dcd_sof_enable(uint8_t rhport, bool en)
 #if TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3, OPT_MCU_ESP32P4)
 
 // Reset opened IN/OUT endpoint counters
-static void dcd_edpt_reset(uint8_t rhport)
+static void dcd_edpt_counters_reset(uint8_t rhport)
 {
-  dwc_ep_config[rhport].in_ep = 0;
-  dwc_ep_config[rhport].out_ep = 0;
+  dwc2_ep_counters[rhport].active_in = 0;
+  dwc2_ep_counters[rhport].active_out = 0;
 }
 
-// Check if IN/OUT endpoint is available before opening it
-static bool dcd_edpt_available(uint8_t rhport, uint8_t dir)
+// Check if IN/OUT endpoint counter is available before opening endpoint
+// return values:
+// true : Endpoint available, value increased by one
+// false : No more endpoints available, counter value reached maximum value
+static bool dcd_edpt_counter_available(uint8_t rhport, uint8_t dir)
 {
     // Verify that we have a vacant EP
-    if ((dwc_ep_config[rhport].in_ep + dwc_ep_config[rhport].out_ep) > (dwc_ep_config[rhport].ep_max_count - 1)) {
+    if ((dwc2_ep_counters[rhport].active_in + dwc2_ep_counters[rhport].active_out) >
+            (dwc2_ep_counters[rhport].max_total - 1)) {
         return false;
     }
     // Get the ep_count amount at the moment as a temporal variable and update it
-    uint8_t new_ep_count = (dir) ? dwc_ep_config[rhport].in_ep : dwc_ep_config[rhport].out_ep;
+    uint8_t new_ep_count = (dir) ? dwc2_ep_counters[rhport].active_in : dwc2_ep_counters[rhport].active_out;
     new_ep_count++;
 
     // Verify overflow for IN EP ESP32Sx
  #if TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3)
      // ESP32Sx has 6 endpoints, from which only 5 can be configured as IN
-     if ((dir) && (new_ep_count > (dwc_ep_config[rhport].ep_max_count - 1))) {
+     if ((dir) && (new_ep_count > (dwc2_ep_counters[rhport].max_total - 1))) {
          return false;
      }
  #endif // TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3)
     // Write new value back
     if(dir) {
-        dwc_ep_config[rhport].in_ep = new_ep_count;
+        dwc2_ep_counters[rhport].active_in = new_ep_count;
     } else {
-        dwc_ep_config[rhport].out_ep = new_ep_count;
+        dwc2_ep_counters[rhport].active_out = new_ep_count;
     }
     return true;
 }
 
 // Release an endpoint.
-static bool dcd_edpt_release(uint8_t rhport, uint8_t dir)
+static bool dcd_edpt_counter_release(uint8_t rhport, uint8_t dir)
 {
   if (dir) {
-    TU_ASSERT(dwc_ep_config[rhport].in_ep == 0);    // Check if number of opened EPs is not zero
-    dwc_ep_config[rhport].in_ep--;                  // Release in_ep
+    TU_ASSERT(dwc2_ep_counters[rhport].active_in == 0);    // Check if number of opened EPs is not zero
+    dwc2_ep_counters[rhport].active_in--;                  // Decrease endpoint counter
   } else {
-    TU_ASSERT(dwc_ep_config[rhport].out_ep == 0);
-    dwc_ep_config[rhport].out_ep--;
+    TU_ASSERT(dwc2_ep_counters[rhport].active_out == 0);
+    dwc2_ep_counters[rhport].active_out--;
   }
   return true;
 }
@@ -691,8 +695,8 @@ bool dcd_edpt_open (uint8_t rhport, tusb_desc_endpoint_t const * desc_edpt)
   uint8_t const dir   = tu_edpt_dir(desc_edpt->bEndpointAddress);
 
   #if TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3, OPT_MCU_ESP32P4)
-  if (!dcd_edpt_available(rhport, dir)) {
-    TU_LOG(1, "No endpoints available (ep_max=%d) \r\n", dwc_ep_config[rhport].ep_max_count);
+  if (!dcd_edpt_counter_available(rhport, dir)) {
+    TU_LOG(1, "No endpoints available (ep_max=%d) \r\n", dwc2_ep_counters[rhport].max_total);
     return false;
   }
   #endif // OPT_MCU_ESP32S2, OPT_MCU_ESP32S3, OPT_MCU_ESP32P4
@@ -777,7 +781,7 @@ void dcd_edpt_close_all (uint8_t rhport)
   uint8_t const ep_count = _dwc2_controller[rhport].ep_count;
 
   #if TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3, OPT_MCU_ESP32P4)
-  dcd_edpt_reset(rhport);
+  dcd_edpt_counters_reset(rhport);
   #endif
 
   // Disable non-control interrupt
@@ -940,7 +944,7 @@ void dcd_edpt_close (uint8_t rhport, uint8_t ep_addr)
   #if TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3, OPT_MCU_ESP32P4)
   // Release an endpoint if it is not the 0 EP
   if (epnum) {
-    dcd_edpt_release(rhport, dir);
+    dcd_edpt_counter_release(rhport, dir);
   }
   #endif
 
@@ -1297,7 +1301,7 @@ void dcd_int_handler(uint8_t rhport)
     dwc2->gintsts = GINTSTS_USBRST;
     bus_reset(rhport);
   #if TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3, OPT_MCU_ESP32P4)
-    dcd_edpt_reset(rhport);
+    dcd_edpt_counters_reset(rhport);
   #endif // OPT_MCU_ESP32S2, OPT_MCU_ESP32S3, OPT_MCU_ESP32P4
   }
 

--- a/src/portable/synopsys/dwc2/dwc2_esp32.h
+++ b/src/portable/synopsys/dwc2/dwc2_esp32.h
@@ -82,13 +82,13 @@ static const dwc2_controller_t _dwc2_controller[] =
 #endif
 };
 
-static dwc_ep_config_t dwc_ep_config[] = 
+static dwc2_ep_counters_t dwc2_ep_counters[] =
 {
 #ifdef DWC2_FS_PERIPH_BASE
-  { .out_ep = 0, .in_ep = 0, .ep_max_count = DWC2_FS_EP_MAX },
+  { .active_out = 0, .active_in = 0, .max_total = DWC2_FS_EP_MAX },
 #endif
 #ifdef DWC2_HS_PERIPH_BASE
-  { .out_ep = 0, .in_ep = 0, .ep_max_count = DWC2_HS_EP_MAX },
+  { .active_out = 0, .active_in = 0, .max_total = DWC2_HS_EP_MAX },
 #endif
 };
 

--- a/src/portable/synopsys/dwc2/dwc2_type.h
+++ b/src/portable/synopsys/dwc2/dwc2_type.h
@@ -34,10 +34,10 @@ typedef struct
 
 #if TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3, OPT_MCU_ESP32P4)
 typedef struct {
-    uint8_t out_ep;
-    uint8_t in_ep;
-    const uint8_t ep_max_count;
-}dwc_ep_config_t;
+    uint8_t active_out;
+    uint8_t active_in;
+    const uint8_t max_total;
+}dwc2_ep_counters_t;
 #endif
 
 /* DWC OTG HW Release versions */


### PR DESCRIPTION
**Describe the PR**
1. Added reset opened IN/OUT EPs counters on dcd_dwc2 `bus_reset` event.
2. Changed the function names to get a bit cleaner idea of logic. 

**Additional context**
Without resetting the values, during re-connection to the Virtual Machine the counters will be overflowed during the next interface creation on device enumeration. 

During the reconnection to the Virtual Machine, the USB bus reset requested several times.
During this event we need to reset the counters for IN/OUT opened EPs, which was added in https://github.com/espressif/tinyusb/pull/20 

Close https://github.com/espressif/esp-usb/issues/28