### PR TITLE
feature(ci): Build ESP-IDF examples in CI

### DIFF
--- a/.github/ci/override_managed_component.py
+++ b/.github/ci/override_managed_component.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+#
+# SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import argparse
+from pathlib import Path
+from glob import glob
+from idf_component_tools.manifest import ManifestManager
+
+
+def override_with_local_component(component, local_path, app):
+    app_path = Path(app)
+
+    absolute_local_path = Path(local_path).absolute()
+    if not absolute_local_path.exists():
+        print('[Error] {} path does not exist'.format(local_path))
+        raise Exception
+    if not app_path.exists():
+        print('[Error] {} path does not exist'.format(app_path))
+        raise Exception
+
+    print('[Info] Processing app {}'.format(app))
+    manager = ManifestManager(app_path / 'main', 'app')
+    if '/' not in component:
+        # Prepend with default namespace
+        component_with_namespace = 'espressif/' + component
+
+    try:
+        manager.manifest_tree['dependencies'][component_with_namespace] = {
+            'version': '*',
+            'override_path': str(absolute_local_path)
+            }
+    except KeyError:
+        print('[Error] {} app does not depend on {}'.format(app, component_with_namespace))
+        raise KeyError
+
+    manager.dump()
+
+
+def override_with_local_component_all(component, local_path, apps):
+    # Process wildcard, e.g. "app_prefix_*"
+    apps_with_glob = list()
+    for app in apps:
+        apps_with_glob += glob(app)
+
+    # Go through all collected apps
+    for app in apps_with_glob:
+        try:
+            override_with_local_component(component, local_path, app)
+        except:
+            print("[Error] Could not process app {}".format(app))
+            return -1
+    return 0
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('component', help='Existing component that the app depends on')
+    parser.add_argument('local_path', help='Path to component that will be used instead of the managed version')
+    parser.add_argument('apps', nargs='*', help='List of apps to process')
+    args = parser.parse_args()
+    sys.exit(override_with_local_component_all(args.component, args.local_path, args.apps))

--- a/.github/workflows/build_idf_examples.yml
+++ b/.github/workflows/build_idf_examples.yml
@@ -1,0 +1,28 @@
+name: Build ESP-IDF USB examples
+
+on:
+  schedule:
+    - cron: '0 0 * * SAT' # Saturday midnight
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "latest"]
+    runs-on: ubuntu-20.04
+    container: espressif/idf:${{ matrix.idf_ver }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - name: Build ESP-IDF USB Device examples
+        shell: bash
+        run: |
+          . ${IDF_PATH}/export.sh
+          pip install idf-component-manager==1.5.2 idf-build-apps --upgrade
+          python .github/ci/override_managed_component.py tinyusb . ${IDF_PATH}/examples/peripherals/usb/device/tusb_*
+          cd ${IDF_PATH}
+          idf-build-apps find --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml
+          idf-build-apps build --path examples/peripherals/usb/device/ --recursive --target all --manifest-file examples/peripherals/.build-test-rules.yml


### PR DESCRIPTION
**Describe the PR**
Build esp-idf examples in CI

**Additional context**
During the `espressif/tinyusb` PR it is necessary to verify possibility of building all of the `esp-idf` examples with requesting changes. 

This CI job does: 
- **Add** for all examples in folder `espressif/tinyusb` dependency with a path, pointing to the root of this repository
- **Build** each example for `--target all`

During the build, the following dependencies are using (at the moment): 
```
Processing 3 dependencies:
[1/3] espressif/esp_tinyusb (1.4.4)   /**< Current latest version of esp_tinyusb */
[2/3] espressif/tinyusb (*)           /**< Local tinyusb, from current PR */
[3/3] idf (5.3.0)                     /**< Version of esp-idf, based on the idf_ver matrix */
```

This changes are based on the changes in https://github.com/espressif/esp-usb/pull/29.