### PR TITLE
feature(usbd): Added tud_teardown()

### DIFF
--- a/src/device/usbd.c
+++ b/src/device/usbd.c
@@ -437,6 +437,31 @@ bool tud_init (uint8_t rhport)
   return true;
 }
 
+bool tud_teardown (uint8_t rhport)
+{
+  // skip if nothing to teardown
+  if ( !tud_inited() ) return true;
+
+  TU_LOG(USBD_DBG, "USBD teardown on controller %u\r\n", rhport);
+
+  // Disable interrupt
+  dcd_int_disable(rhport);
+
+  // Disable class devices
+  for (uint8_t i = 0; i < TOTAL_DRIVER_COUNT; i++)
+  {
+    usbd_class_driver_t const * driver = get_driver(i);
+    TU_ASSERT(driver);
+    TU_LOG(USBD_DBG, "%s reset\r\n", driver->name);
+    driver->reset(rhport);
+  }
+
+  // clean port
+  _usbd_rhport = RHPORT_INVALID;
+
+  return true;
+}
+
 static void configuration_reset(uint8_t rhport)
 {
   for ( uint8_t i = 0; i < TOTAL_DRIVER_COUNT; i++ )

--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -43,6 +43,9 @@ bool tud_init (uint8_t rhport);
 // Check if device stack is already initialized
 bool tud_inited(void);
 
+// Teardown device stack
+bool tud_teardown (uint8_t rhport);
+
 // Task function should be called in main/rtos loop, extended version of tud_task()
 // - timeout_ms: millisecond to wait, zero = no wait, 0xFFFFFFFF = wait forever
 // - in_isr: if function is called in ISR

--- a/src/tusb.c
+++ b/src/tusb.c
@@ -58,6 +58,23 @@ bool tusb_init(void)
   return true;
 }
 
+// Teardown device/host stack
+bool tusb_teardown(void)
+{
+#if CFG_TUD_ENABLED && defined(TUD_OPT_RHPORT)
+  // teardown device stack CFG_TUSB_RHPORTx_MODE must be defined
+  TU_ASSERT ( tud_teardown(TUD_OPT_RHPORT) );
+#endif
+
+#if CFG_TUH_ENABLED && defined(TUH_OPT_RHPORT)
+  // teardown host stack CFG_TUSB_RHPORTx_MODE must be defined
+  // not implemented
+  return false;
+#endif
+
+  return true;
+}
+
 bool tusb_inited(void)
 {
   bool ret = false;

--- a/src/tusb.h
+++ b/src/tusb.h
@@ -133,8 +133,8 @@ bool tusb_init(void);
 // Check if stack is initialized
 bool tusb_inited(void);
 
-// TODO
-// bool tusb_teardown(void);
+// Teardown device/host stack
+bool tusb_teardown(void);
 
 #ifdef __cplusplus
  }


### PR DESCRIPTION
### Requirements

When tinyusb driver is configured and installed, there are no option to reconfigure device, without powering cycle.

To be able to change USB Device class with reinstalling tinyusb driver, there should be a mechanism to teardown (disble, close and free) everything inside tinyusb.  

### Limitations
- Available only for Device stack (Not implemented with `TUH_OPT_RHPORT`)
- Verified only for dcd_dwc2 hardware. (`tud_teadown()` calls `dcd_int_disable()` which should be implemented in dcd layer)

### Breaking change
- Added `bool tud_teardown (uint8_t rhport)` in usbd.c. This is a breaking change for previous versions. 

Close https://github.com/espressif/esp-idf/issues/13788
