### PR TITLE
feature(tinyusb): Implemented various changes for the main logic of driver

### DIFF
--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -683,8 +683,9 @@ bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
   // Force device mode
   dwc2->gusbcfg = (dwc2->gusbcfg & ~GUSBCFG_FHMOD) | GUSBCFG_FDMOD;
 
-  // Clear A override, force B Valid
-  dwc2->gotgctl = (dwc2->gotgctl & ~GOTGCTL_AVALOEN) | GOTGCTL_BVALOEN | GOTGCTL_BVALOVAL;
+  // No overrides
+  dwc2->gotgctl &= ~(GOTGCTL_BVALOEN | GOTGCTL_BVALOVAL | GOTGCTL_VBVALOVAL);
+
 
   // If USB host misbehaves during status portion of control xfer
   // (non zero-length packet), send STALL back and discard.

--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -234,7 +234,7 @@ static bool dfifo_alloc(uint8_t rhport, uint8_t ep_addr, uint16_t packet_size) {
     // Check if free space is available
     TU_ASSERT(_dfifo_top >= fifo_size + dwc2->grxfsiz);
     _dfifo_top -= fifo_size;
-    TU_LOG(DWC2_DEBUG, "    TX FIFO %u: allocated %u words at offset %u\r\n", epnum, fifo_size, _dfifo_top);
+    // TU_LOG(DWC2_DEBUG, "    TX FIFO %u: allocated %u words at offset %u\r\n", epnum, fifo_size, _dfifo_top);
 
     // Both TXFD and TXSA are in unit of 32-bit words.
     if (epnum == 0) {

--- a/src/tusb.c
+++ b/src/tusb.c
@@ -57,7 +57,7 @@ bool tusb_rhport_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
       .role = TUSB_ROLE_DEVICE,
       .speed = TUD_OPT_HIGH_SPEED ? TUSB_SPEED_HIGH : TUSB_SPEED_FULL
     };
-    TU_ASSERT ( tud_rhport_init(rhport, &dev_init) );
+    TU_ASSERT ( tud_rhport_init(TUD_OPT_RHPORT, &dev_init) );
     _rhport_role[TUD_OPT_RHPORT] = TUSB_ROLE_DEVICE;
     #endif
 


### PR DESCRIPTION
## Requirements
- [ESP32S2/S3] Fixed the USB VBUS detection
- [ESP32P4] Fixed HS port selection in Device mode for ESP32P4
- [all chips] Disabled one debug line, which could be printed from IRQ and cause KERNEL PANIC

## Limitations
- No support for ESP32P4 FS PHY (USB 1.1)

## Breaking change
_No breaking changes_

## Checklist

- [x] Pull Request name has appropriate format (for example: "fix(dcd_dwc2): Resolved address selection when several phy are present")
- [ ] _Optional:_ README.md updated
- [x] CI passing

## Related issues
_No related issues_

