### PR TITLE
feature(ci): Added esp-iot-solution USB Device examples build verification

### DIFF
--- a/.github/workflows/build_iot_examples.yml
+++ b/.github/workflows/build_iot_examples.yml
@@ -1,0 +1,33 @@
+name: ESP IoT Solution - USB Device Examples
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
+        name: ["usb_uart_bridge"]
+    runs-on: ubuntu-20.04
+    container: espressif/idf:${{ matrix.idf_ver }}
+    env:
+      ESP_IOT_PATH: esp-iot-solution
+      MANIFEST_PATH: esp-iot-solution/examples/.build-rules.yml
+      EXAMPLE_PATH: esp-iot-solution/examples/usb/device/${{ matrix.name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+      - name: Clone esp-iot-solution repository
+        run: |
+          git clone https://github.com/espressif/esp-iot-solution.git
+      - name: Build
+        shell: bash
+        run: |
+          . ${IDF_PATH}/export.sh
+          pip install idf-component-manager==1.5.2 idf-build-apps==2.4.3 --upgrade
+          python .github/ci/override_managed_component.py tinyusb . ${{ env.EXAMPLE_PATH }}/
+          idf-build-apps find --paths ${{ env.EXAMPLE_PATH }} --target all --manifest-file ${{ env.MANIFEST_PATH }} --manifest-rootpath ${{ env.ESP_IOT_PATH }}
+          idf-build-apps build --paths ${{ env.EXAMPLE_PATH }} --target all --manifest-file ${{ env.MANIFEST_PATH }} --manifest-rootpath ${{ env.ESP_IOT_PATH }}


### PR DESCRIPTION
## Requirements
Increase the verification for incoming changes for espressif/tinyusb. 
Add building of the examples from esp-iot-solutions to the CI process. 

## Description
The job names were modified regarding the following naming pattern: [REPO_NAME][JOB_NAME] - [STEP_NAME]
Where:

REPO_NAME = [ESP-IDF, ESP-USB]
JOB_NAME = [Build, Run]
STEP_NAME = [build, run-target]

## Limitations
- Only for `usb_uart_bridge` example so far, because it is the only one which can be built with using the local tinyusb component.  

## Breaking change
_No breaking changes_

## Checklist

- [x] Pull Request name has appropriate format (for example: "fix(dcd_dwc2): Resolved address selection when several phy are present")
- [ ] _Optional:_ README.md updated
- [x] CI passing

## Related issues
_No related issues_