### PR TITLE
feature(uvc): Applied proprietary changes in UVC Device class

### DIFF
--- a/src/class/video/video_device.c
+++ b/src/class/video/video_device.c
@@ -622,7 +622,8 @@ static bool _negotiate_streaming_parameters(videod_streaming_interface_t const *
     tusb_desc_cs_video_fmt_t const *fmt = _find_desc_format(tu_desc_next(vs), end, fmtnum);
     tusb_desc_cs_video_frm_t const *frm = _find_desc_frame(tu_desc_next(fmt), end, frmnum);
 
-    uint_fast32_t interval, interval_ms;
+    uint_fast32_t interval = 0;
+    uint_fast32_t interval_ms = 0;
     switch (request) {
       case VIDEO_REQUEST_GET_MAX: {
         uint_fast32_t min_interval, max_interval;


### PR DESCRIPTION
## Requirements
- Fixed uninitialized values during streaming negotiation parameters
- Added `VIDEO_CS_ITF_VS_FORMAT_FRAME_BASED` support

## Limitations
N/A

## Breaking change
_No breaking changes_

## Testing:
 - After applying changes the `esp-video-components/esp_video/examples/uvc` could be built successfully: 
 
![image](https://github.com/user-attachments/assets/efc5bc4a-a242-4df6-b2a5-7227cd856d20)

![image](https://github.com/user-attachments/assets/a94178f1-653b-4935-9b1e-664f80a69455)

*NOTE: Modified component `usb_device_uvc` was used to enable possibility to use `espressif/tinyusb` component by local path. 

## Checklist

- [x] Pull Request name has appropriate format (for example: "fix(dcd_dwc2): Resolved address selection when several phy are present")
- [ ] _Optional:_ README.md updated
- [x] CI passing

## Related issues
- Changes applied also in synchronization commit:  https://github.com/espressif/tinyusb/pull/43
- Resolves fix: https://github.com/espressif/esp-video-components/commit/6e61b6fa10cdce9efe317bb4dd3e83f20ce58133#diff-f742676e9225ab4ba99adff463cfe58296bb400490cc0e4f5c635567e6be634d
- Upstream PR: https://github.com/hathach/tinyusb/pull/2656


