### PR TITLE
feature(tinyusb) : Updated build scripts for upstream v0.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(srcs
     "src/class/dfu/dfu_rt_device.c"
     # Common, device-mode related
     "src/portable/synopsys/dwc2/dcd_dwc2.c"
+    "src/portable/synopsys/dwc2/dwc2_common.c"
     "src/common/tusb_fifo.c"
     "src/device/usbd_control.c"
     "src/device/usbd.c"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 idf_build_get_property(target IDF_TARGET)
 
-if(target STREQUAL "esp32s3")
+if(${target} STREQUAL "esp32s3")
     set(tusb_mcu "OPT_MCU_ESP32S3")
     set(tusb_family "esp32sx")
-elseif(target STREQUAL "esp32s2")
+elseif(${target} STREQUAL "esp32s2")
     set(tusb_mcu "OPT_MCU_ESP32S2")
     set(tusb_family "esp32sx")
-elseif(target STREQUAL "esp32p4")
+elseif(${target} STREQUAL "esp32p4")
     set(tusb_mcu "OPT_MCU_ESP32P4")
     set(tusb_family "esp32px")
 endif()
@@ -53,10 +53,20 @@ set(srcs
     "src/tusb.c"
     )
 
+set(requirements_private
+    esp_netif   # required by rndis_reports.c: #include "netif/ethernet.h"
+    )
+
+if(${target} STREQUAL "esp32p4")
+    list(APPEND requirements_private
+                esp_mm # required by dcd_dwc2.c: #include "esp_cache.h"
+        )
+endif()
+
 idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS ${includes_public}
                        PRIV_INCLUDE_DIRS ${includes_private}
-                       PRIV_REQUIRES esp_netif # required by rndis_reports.c: #include "netif/ethernet.h"
+                       PRIV_REQUIRES  ${requirements_private}
                        )
 
 target_compile_options(${COMPONENT_LIB} PUBLIC ${compile_options})


### PR DESCRIPTION
## Requirements
To enable build for tinyusb component we need to add: 
1. New source file `dwc2_common.c`
2. Component dependency for `esp_mm` for esp32p4

## Limitations
N/A

## Breaking change
_No breaking changes_

## Checklist

- [x] Pull Request name has appropriate format (for example: "fix(dcd_dwc2): Resolved address selection when several phy are present")
- [ ] _Optional:_ README.md updated
- [x] CI passing

## Related issues
* Cherry-picked from https://github.com/espressif/tinyusb/pull/37


