### PR TITLE
fix(usbd/dcd_dwc2): Fixed epin counter assert, update buffer name for TU_LOG > 1

### DIFF
--- a/src/device/usbd_control.c
+++ b/src/device/usbd_control.c
@@ -174,7 +174,7 @@ bool usbd_control_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t result,
   if (_ctrl_xfer.request.bmRequestType_bit.direction == TUSB_DIR_OUT) {
     TU_VERIFY(_ctrl_xfer.buffer);
     memcpy(_ctrl_xfer.buffer, _ctrl_epbuf.buf, xferred_bytes);
-    TU_LOG_MEM(CFG_TUD_LOG_LEVEL, _usbd_ctrl_buf, xferred_bytes, 2);
+    TU_LOG_MEM(CFG_TUD_LOG_LEVEL, _ctrl_xfer.buffer, xferred_bytes, 2);
   }
 
   _ctrl_xfer.total_xferred += (uint16_t) xferred_bytes;

--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -543,7 +543,7 @@ void dcd_edpt_close_all(uint8_t rhport) {
   dwc2_regs_t* dwc2 = DWC2_REG(rhport);
   uint8_t const ep_count = _dwc2_controller[rhport].ep_count;
 
-  _dcd_data.allocated_epin_count = 1;
+  _dcd_data.allocated_epin_count = 0;
 
   // Disable non-control interrupt
   dwc2->daintmsk = (1 << DAINTMSK_OEPM_Pos) | (1 << DAINTMSK_IEPM_Pos);
@@ -654,7 +654,7 @@ static void handle_bus_reset(uint8_t rhport) {
   tu_memclr(xfer_status, sizeof(xfer_status));
 
   _dcd_data.sof_en = false;
-  _dcd_data.allocated_epin_count = 1;
+  _dcd_data.allocated_epin_count = 0;
 
   // 1. NAK for all OUT endpoints
   for (uint8_t n = 0; n < ep_count; n++) {

--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -195,8 +195,8 @@ static bool dfifo_alloc(uint8_t rhport, uint8_t ep_addr, uint16_t packet_size) {
     }
   } else {
     // Check IN endpoints concurrently active limit
-    if(_dwc2_controller->ep_in_count) {
-      TU_ASSERT(_dcd_data.allocated_epin_count < _dwc2_controller->ep_in_count);
+    if(dwc2_controller->ep_in_count) {
+      TU_ASSERT(_dcd_data.allocated_epin_count < dwc2_controller->ep_in_count);
       _dcd_data.allocated_epin_count++;
     }
 


### PR DESCRIPTION
## Requirements
1. When `TU_LOG` configured with value > 1 we need to provide correct name for `TU_LOG_MEM()` macros.
2. This PR contain two small fixes, which are crucial for using device configuration with fully load EP amount.
ESP32S2/S3 and ESP32P4.

## Description
1. Flushing _dcd_data.allocated_epin_count to zero while:
    - `dcd_edpt_close_all()` as we will allocate FIFO for EP0 later in `dfifo_device_init(rhport);`
    - `handle_bus_reset(uint8_t rhport)` as we will allocate FIFO for EP0 later in `dfifo_device_init(rhport);`
2. Fix the usage of counters for TU_ASSERT. When we use _dwc2_controller instead of dwc2_controller we request the ep_in_count member value from the first member, which is FS. This is important, when we run on HS PHY.
3. Changed `_usbd_ctrl_buf` -> `_ctrl_xfer.buffer`

## Limitations
N/A

## Breaking change
_No breaking changes_

## Checklist

- [x] Pull Request name has appropriate format (for example: "fix(dcd_dwc2): Resolved address selection when several phy are present")
- [ ] _Optional:_ README.md updated
- [x] CI passing

## Related issues
- Cherry-picked to the upstream: https://github.com/hathach/tinyusb/pull/2891
- Cherry-picked to the upstream: https://github.com/hathach/tinyusb/pull/2892