### PR TITLE
ci(tinyusb): Added esp-usb test_apps build and run (esp32s2)

### DIFF
--- a/.github/workflows/build_and_run_esp_usb_test_apps.yml
+++ b/.github/workflows/build_and_run_esp_usb_test_apps.yml
@@ -1,0 +1,79 @@
+name: ESP-USB Test Apps
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      fail-fast: false
+      matrix:
+        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
+    runs-on: ubuntu-20.04
+    container: espressif/idf:${{ matrix.idf_ver }}
+    env:
+      ESP_USB_MANIFEST: ./esp-usb/.build-test-rules.yml
+      ESP_TINYUSB_TEST_APPS: ./esp-usb/device/esp_tinyusb/test_apps
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+      - name: Clone esp-usb repository
+        run: |
+            git clone https://github.com/espressif/esp-usb.git
+      - name: Build
+        shell: bash
+        run: |
+          . ${IDF_PATH}/export.sh
+          pip install idf-component-manager==1.5.2 idf-build-apps==2.4.3 --upgrade
+          export PEDANTIC_FLAGS="-DIDF_CI_BUILD -Werror -Werror=deprecated-declarations -Werror=unused-variable -Werror=unused-but-set-variable -Werror=unused-function"
+          export EXTRA_CFLAGS="${PEDANTIC_FLAGS} -Wstrict-prototypes"
+          export EXTRA_CXXFLAGS="${PEDANTIC_FLAGS}"
+          python .github/ci/override_managed_component.py tinyusb . ${{ env.ESP_TINYUSB_TEST_APPS }}/*/
+          idf-build-apps find --path ${{ env.ESP_TINYUSB_TEST_APPS }}/ --recursive --target esp32s2 --manifest-file ${{ env.ESP_USB_MANIFEST }}
+          idf-build-apps build --path ${{ env.ESP_TINYUSB_TEST_APPS }}/ --recursive --target esp32s2 --manifest-file ${{ env.ESP_USB_MANIFEST }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: usb_test_app_bin_${{ matrix.idf_ver }}
+          path: |
+            ${{env.ESP_TINYUSB_TEST_APPS}}/**/build/bootloader/bootloader.bin
+            ${{env.ESP_TINYUSB_TEST_APPS}}/**/build/partition_table/partition-table.bin
+            ${{env.ESP_TINYUSB_TEST_APPS}}/**/build/test_app_*.bin
+            ${{env.ESP_TINYUSB_TEST_APPS}}/**/build/test_app_*.elf
+            ${{env.ESP_TINYUSB_TEST_APPS}}/**/build/flasher_args.json
+            ${{env.ESP_TINYUSB_TEST_APPS}}/**/build/config/sdkconfig.json
+          if-no-files-found: error
+
+  run-target:
+    name: Run
+    if: ${{ github.repository_owner == 'espressif' }}
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
+        idf_target: ["esp32s2"]
+        runner_tag: ["usb_device"]
+    runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}"]
+    container:
+      image: python:3.11-bookworm
+      options: --privileged --device-cgroup-rule="c 188:* rmw" --device-cgroup-rule="c 166:* rmw"
+    env:
+      ESP_TINYUSB_TEST_APPS: ./esp-usb/device/esp_tinyusb/test_apps
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clone esp-usb repository
+        run: |
+          git clone https://github.com/espressif/esp-usb.git
+      - name: Install Python packages
+        env:
+          PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"
+        run: pip install --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf pyserial pyusb
+      - uses: actions/download-artifact@v4
+        with:
+          name: usb_test_app_bin_${{ matrix.idf_ver }}
+          path: ${{env.ESP_TINYUSB_TEST_APPS}}
+      - name: Run USB Test App on target
+        run: pytest ${{env.ESP_TINYUSB_TEST_APPS}} --embedded-services esp,idf --target=${{ matrix.idf_target }} -m ${{ matrix.runner_tag }}

--- a/.github/workflows/build_idf_examples.yml
+++ b/.github/workflows/build_idf_examples.yml
@@ -1,4 +1,4 @@
-name: Build ESP-IDF USB examples
+name: ESP-IDF USB Device examples
 
 on:
   schedule:
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
-      - name: Build ESP-IDF USB Device examples
+      - name: Build
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh


### PR DESCRIPTION
## Requirements
Run a pytest verification for esp-usb test applications with incoming changes for espressif/tinyusb. 

## Description

The job names were modified regarding the following naming pattern:  [REPO_NAME][JOB_NAME] - [STEP_NAME]
Where: 
- REPO_NAME = [ESP-IDF, ESP-USB]
- JOB_NAME = [Build, Run]
- STEP_NAME = [build, run-target]

## Limitations
- Only for esp32s2

## Breaking change
_No breaking changes_

## Checklist

- [x] Pull Request name has appropriate format (for example: "fix(dcd_dwc2): Resolved address selection when several phy are present")
- [ ] _Optional:_ README.md updated
- [x] CI passing

## Related issues
_No related issues_



