### PR TITLE
feature(tusb): Added tusb_teardown()

### DIFF
--- a/src/tusb.c
+++ b/src/tusb.c
@@ -136,6 +136,40 @@ void tusb_int_handler(uint8_t rhport, bool in_isr) {
   #endif
 }
 
+bool tusb_rhport_teardown(uint8_t rhport) {
+  // backward compatible call with tusb_init(void)
+  #if defined(TUD_OPT_RHPORT) || defined(TUH_OPT_RHPORT)
+    #if CFG_TUD_ENABLED && defined(TUD_OPT_RHPORT)
+    // deinit device stack, CFG_TUSB_RHPORTx_MODE must be defined
+    TU_ASSERT( tud_deinit(TUD_OPT_RHPORT) );
+    _tusb_rhport_role[TUD_OPT_RHPORT] = TUSB_ROLE_INVALID;
+    #endif
+
+    #if CFG_TUH_ENABLED && defined(TUH_OPT_RHPORT)
+    // deinit host stack CFG_TUSB_RHPORTx_MODE must be defined
+    TU_ASSERT( tuh_deinit(TUH_OPT_RHPORT) );
+    _tusb_rhport_role[TUH_OPT_RHPORT] = TUSB_ROLE_INVALID;
+    #endif
+
+    return true;
+  #endif
+
+  // new API with explicit rhport and role
+  TU_ASSERT(rhport < TUP_USBIP_CONTROLLER_NUM);
+
+  #if CFG_TUD_ENABLED
+  TU_ASSERT( tud_deinit(rhport) );
+  _tusb_rhport_role[rhport] = TUSB_ROLE_INVALID;
+  #endif
+
+  #if CFG_TUH_ENABLED
+  TU_ASSERT(  tuh_deinit(rhport) );
+  _tusb_rhport_role[rhport] = TUSB_ROLE_INVALID;
+  #endif
+
+  return true;
+}
+
 //--------------------------------------------------------------------+
 // Descriptor helper
 //--------------------------------------------------------------------+

--- a/src/tusb.h
+++ b/src/tusb.h
@@ -154,14 +154,24 @@ bool tusb_inited(void);
 // Called to handle usb interrupt/event. tusb_init(rhport, role) must be called before
 void tusb_int_handler(uint8_t rhport, bool in_isr);
 
-// TODO
-// bool tusb_teardown(void);
+// Internal helper for backward compatibility with tusb_init(void)
+bool tusb_rhport_teardown(uint8_t rhport);
+
+#if defined(TUD_OPT_RHPORT) || defined(TUH_OPT_RHPORT)
+  #define _tusb_teardown_arg0()        tusb_rhport_teardown(0)
+#else
+  #define _tusb_teardown_arg0()        TU_VERIFY_STATIC(false, "CFG_TUSB_RHPORT0_MODE/CFG_TUSB_RHPORT1_MODE must be defined")
+#endif
+
+#define _tusb_teardown_arg1(_rhport)         tusb_rhport_teardown(_rhport)
+#define tusb_teardown(...)                   TU_FUNC_OPTIONAL_ARG(_tusb_teardown, __VA_ARGS__)
 
 #else
 
 #define tusb_init(...)  (false)
 #define tusb_int_handler(...)  do {}while(0)
 #define tusb_inited()  (false)
+#define tusb_teardown(...) (false)
 
 #endif
 


### PR DESCRIPTION
## Requirements
To change the USB device function or re-initialize the tinyusb stack there should be an option to teardown the lower layer (disable the phy and flush the registers).

The public API for init tinyusb stack for USB Device is `tusb_init(void)` for versions < v0.17,  and `tusb_rhport_init(rhport, *rh_init)` for verisons >= 0.17. 

Teardown feature should be implemented as a public API for Device and Host roles and provide the possibility to use the teardown call in both (legacy and new API way)

## Description

The same mechanism for legacy call support is used as for `tusb_init()` (providing the `rhport` as `TUD_OPT_RHPORT` or `TUH_OPT_RHPORT` but not the function argument)
 
## Limitations
- Using macros to handle the legacy support instead of function (refer to Note2: https://github.com/hathach/tinyusb/blob/7c7b30f0ae66a856ada3526cb947bd3a255567f8/src/tusb.h#L140)

## Breaking change
_No breaking changes_

## Testing:
Implemented in https://github.com/espressif/esp-usb/pull/39

## Checklist

- [x] Pull Request name has appropriate format (for example: "fix(dcd_dwc2): Resolved address selection when several phy are present")
- [ ] _Optional:_ README.md updated
- [x] CI passing

## Related issues
- Related to  https://github.com/espressif/esp-idf/issues/13788
- Upstream PR: https://github.com/hathach/tinyusb/pull/2904


