### PR TITLE
change(ci): Added usbtool for docker (v0.17) 

### DIFF
--- a/.github/workflows/build_and_run_esp_usb_test_apps.yml
+++ b/.github/workflows/build_and_run_esp_usb_test_apps.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Clone esp-usb repository
         run: |
           git clone https://github.com/espressif/esp-usb.git
+      - name: ⚙️ Install System tools
+        run: |
+          apt update
+          apt install -y usbutils
       - name: Install Python packages
         env:
           PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"


### PR DESCRIPTION
## Requirements
Unlock CI (fix teardown verification)

USB teardown feature [were](https://github.com/espressif/esp-usb/pull/39) added in ESP USB repository. 
To run USB Test Application in tinyusb repository, usbtools should present in docker image.  

## Description
Adding installation of usbtool to workflow

 ## Limitations
N/A

## Breaking change
_No breaking changes_

## Testing:
N/A

## Checklist

- [x] Pull Request name has appropriate format (for example: "fix(dcd_dwc2): Resolved address selection when several phy are present")
- [ ] _Optional:_ README.md updated
- [x] CI passing

## Related issues
- https://github.com/espressif/esp-usb/pull/39
