### PR TITLE
ci(workflow): Update ubuntu runners to ubuntu-latest

### DIFF
--- a/.github/workflows/build_and_run_esp_usb_test_apps.yml
+++ b/.github/workflows/build_and_run_esp_usb_test_apps.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     env:
       ESP_USB_MANIFEST: ./esp-usb/.build-test-rules.yml

--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
       fail-fast: false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_iot_examples.yml
+++ b/.github/workflows/build_iot_examples.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         idf_ver: ["release-v5.0", "release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "latest"]
         name: ["usb_uart_bridge"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     env:
       ESP_IOT_PATH: esp-iot-solution


### PR DESCRIPTION
## Requirements
Refer to https://github.com/actions/runner-images/issues/11101

## Description
Change `runs-on: ubuntu-20.04` -> `runs-on: ubuntu-latest`

 ## Limitations
N/A

## Breaking change
_No breaking changes_

## Testing:
N/A

## Checklist

- [x] Pull Request name has appropriate format (for example: "fix(dcd_dwc2): Resolved address selection when several phy are present")
- [X] _Optional:_ README.md updated
- [x] CI passing

## Related issues
N/A
