### PR TITLE
feature(usbtmc): add usbtmc device class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(srcs
     "src/class/audio/audio_device.c"
     "src/class/video/video_device.c"
     "src/class/bth/bth_device.c"
+    "src/class/usbtmc/usbtmc_device.c"
     # NET class
     "src/class/net/ecm_rndis_device.c"
     "lib/networking/rndis_reports.c"


### PR DESCRIPTION
**Describe the PR**
Add the usbtmc device class

**Additional context**
The USBTMC device class works well on the ESP32S3.
I modified the tinyusb usbtmc example to work with these TinyUsb component in the ESP-IDF for testing.
It works fine with the visaQuery.py from the example.
I tested it with and without 488 mode enabled.
