### PR TITLE
fix(ci): Cleanup and extension of workflows [v0.18]

### DIFF
--- a/.github/ci/.build_and_run_idf_examples_config.toml
+++ b/.github/ci/.build_and_run_idf_examples_config.toml
@@ -1,0 +1,22 @@
+# Config file for build_and_run_idf_examples.yml workflow
+
+# This file contains configuration settings for the idf-build-apps tool,
+# which is used to build and run example applications in the workflow.
+# If you change the 'build_dir' value, make sure to update the corresponding
+# Run step in the workflow, as it will need to reference the new build directory.
+
+paths = [
+    "${IDF_PATH}/examples/peripherals/usb/device",     # ESP-IDF USB Device examples path
+]
+
+exclude = [
+    "${IDF_PATH}/examples/peripherals/usb/device/cherryusb_serial_device", # Exclude cherryusb-based device examples
+]
+
+recursive = true
+manifest_file = "${IDF_PATH}/examples/peripherals/.build-test-rules.yml"
+check_warnings = true
+target = "all"
+
+# Build related options (build_dir uses '@t' for target and '@w' for wildcard pattern (sdkconfig usually)
+build_dir = "build_@t_@w"

--- a/.github/workflows/build_and_run_esp_usb_test_apps.yml
+++ b/.github/workflows/build_and_run_esp_usb_test_apps.yml
@@ -1,4 +1,8 @@
-name: ESP-USB Test Apps
+# This workflow builds and runs ESP-USB test applications for pull requests.
+# It checks out the latest code from ESP-USB master, builds test apps using Espressif's IDF,
+# uploads artifacts, and runs tests on self-hosted runners for supported targets.
+
+name: ESP-USB Test Apps [master]
 
 on:
   pull_request:
@@ -8,13 +12,19 @@ jobs:
   build:
     name: Build
     strategy:
+      fail-fast: false
       matrix:
         idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "latest"]
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     env:
-      ESP_USB_MANIFEST: ./esp-usb/.build-test-rules.yml
-      ESP_TINYUSB_TEST_APPS: ./esp-usb/device/esp_tinyusb/test_apps
+      IDF_COMP_MAN_VER: "2.4.3"
+      IDF_BUILD_APPS_VER: "2.13.1"
+      # We are cloning esp-usb repo to get the test apps to build, the paths should be configured explicitly
+      ESP_USB_PATH: esp-usb
+      ESP_USB_CONFIG_FILE: esp-usb/.idf_build_apps.toml
+      ESP_USB_MANIFEST: esp-usb/.build-test-rules.yml
+      ESP_TINYUSB_TEST_APPS: esp-usb/device/esp_tinyusb/test_apps
     steps:
       - uses: actions/checkout@v4
         with:
@@ -26,40 +36,45 @@ jobs:
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install --no-cache-dir idf-component-manager>=2.1.2 idf-build-apps==2.4.3 pyyaml --upgrade
+          pip install --no-cache-dir idf-component-manager>=${{ env.IDF_COMP_MAN_VER }} idf-build-apps==${{ env.IDF_BUILD_APPS_VER }} pyyaml --upgrade
           export PEDANTIC_FLAGS="-DIDF_CI_BUILD -Werror -Werror=deprecated-declarations -Werror=unused-variable -Werror=unused-but-set-variable -Werror=unused-function"
           export EXTRA_CFLAGS="${PEDANTIC_FLAGS} -Wstrict-prototypes"
           export EXTRA_CXXFLAGS="${PEDANTIC_FLAGS}"
           python .github/ci/override_managed_component.py tinyusb . ${{ env.ESP_TINYUSB_TEST_APPS }}/*/
-          idf-build-apps find --path ${{ env.ESP_TINYUSB_TEST_APPS }}/ --recursive --target esp32s2 --manifest-file ${{ env.ESP_USB_MANIFEST }}
-          idf-build-apps build --path ${{ env.ESP_TINYUSB_TEST_APPS }}/ --recursive --target esp32s2 --manifest-file ${{ env.ESP_USB_MANIFEST }}
+          idf-build-apps find --config-file ${{ env.ESP_USB_CONFIG_FILE }} -p ${{ env.ESP_TINYUSB_TEST_APPS }} -t all --manifest-files ${{ env.ESP_USB_MANIFEST }} --manifest-rootpath ${{ env.ESP_USB_PATH }}
+          idf-build-apps build --config-file ${{ env.ESP_USB_CONFIG_FILE }} -p ${{ env.ESP_TINYUSB_TEST_APPS }} -t all --manifest-files ${{ env.ESP_USB_MANIFEST }} --manifest-rootpath ${{ env.ESP_USB_PATH }}
       - uses: actions/upload-artifact@v4
         with:
-          name: usb_test_app_bin_${{ matrix.idf_ver }}
+          # Test apps builds live under the repository workspace, we use workspace-relative glob
+          name: usb_device_test_app_bin_${{ matrix.idf_ver }}
           path: |
-            ${{env.ESP_TINYUSB_TEST_APPS}}/**/build/bootloader/bootloader.bin
-            ${{env.ESP_TINYUSB_TEST_APPS}}/**/build/partition_table/partition-table.bin
-            ${{env.ESP_TINYUSB_TEST_APPS}}/**/build/test_app_*.bin
-            ${{env.ESP_TINYUSB_TEST_APPS}}/**/build/test_app_*.elf
-            ${{env.ESP_TINYUSB_TEST_APPS}}/**/build/flasher_args.json
-            ${{env.ESP_TINYUSB_TEST_APPS}}/**/build/config/sdkconfig.json
+            **/build_esp*/bootloader/bootloader.bin
+            **/build_esp*/partition_table/partition-table.bin
+            **/build_esp*/test_app_*.bin
+            **/build_esp*/test_app_*.elf
+            **/build_esp*/flasher_args.json
+            **/build_esp*/config/sdkconfig.json
           if-no-files-found: error
 
   run-target:
     name: Run
+    # Disable the job in forks
     if: ${{ github.repository_owner == 'espressif' }}
     needs: build
     strategy:
+      fail-fast: false
       matrix:
         idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "latest"]
         idf_target: ["esp32s2"]
+        sdkconfig: ["default"]
         runner_tag: ["usb_device"]
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}"]
     container:
       image: python:3.11-bookworm
       options: --privileged --device-cgroup-rule="c 188:* rmw" --device-cgroup-rule="c 166:* rmw"
     env:
-      ESP_TINYUSB_TEST_APPS: ./esp-usb/device/esp_tinyusb/test_apps
+      ESP_USB_ROOT: esp-usb
+      ESP_USB_TEST_APPS_PATH: esp-usb/device/esp_tinyusb/test_apps
     steps:
       - uses: actions/checkout@v4
       - name: Clone esp-usb repository
@@ -75,7 +90,9 @@ jobs:
         run: pip install --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf pyserial pyusb
       - uses: actions/download-artifact@v4
         with:
-          name: usb_test_app_bin_${{ matrix.idf_ver }}
-          path: ${{env.ESP_TINYUSB_TEST_APPS}}
-      - name: Run USB Test App on target
-        run: pytest ${{env.ESP_TINYUSB_TEST_APPS}} --embedded-services esp,idf --target=${{ matrix.idf_target }} -m ${{ matrix.runner_tag }}
+          # No need to set the path manually.
+          # The test apps were built after cloning the esp-usb repo,
+          # and the build artifacts already have the correct folder structure.
+          name: usb_device_test_app_bin_${{ matrix.idf_ver }}
+      - name: Run on target
+        run: pytest ${{ env.ESP_USB_TEST_APPS_PATH }} --target=${{ matrix.idf_target }} -m ${{ matrix.runner_tag }} --build-dir=build_${{ matrix.idf_target }}_${{ matrix.sdkconfig }}

--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -6,62 +6,76 @@ on:
 
 jobs:
   build:
+    name: Build
     strategy:
+      fail-fast: false
       matrix:
         idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "latest"]
-      fail-fast: false
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
+    env:
+      IDF_COMP_MAN_VER: "2.4.3"
+      IDF_BUILD_APPS_VER: "2.13.1"
+      CONFIG_PATH: ${{ github.workspace }}/.github/ci/.build_and_run_idf_examples_config.toml
     steps:
       - uses: actions/checkout@v4
       - name: Install Python dependencies
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install --no-cache-dir idf-component-manager>=2.1.2 idf-build-apps==2.4.3 pyyaml --upgrade
+          pip install --no-cache-dir idf-component-manager>=${{ env.IDF_COMP_MAN_VER }} idf-build-apps==${{ env.IDF_BUILD_APPS_VER }} pyyaml --upgrade
       - name: Build Network USB related examples
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
+          # Hint: To build network example we just use default config and network build rules provided by IDF
           export EXAMPLES_PATH="${IDF_PATH}/examples/network/sta2eth"
           export MANIFEST_FILE="${IDF_PATH}/examples/network/.build-test-rules.yml"
-          idf-build-apps find --path ${EXAMPLES_PATH}/ --target esp32s2 --manifest-file ${MANIFEST_FILE}
-          idf-build-apps build --path ${EXAMPLES_PATH}/ --target esp32s2 --manifest-file ${MANIFEST_FILE}
+          python .github/ci/override_managed_component.py tinyusb . ${EXAMPLES_PATH}
+          idf-build-apps find -p ${EXAMPLES_PATH} -t esp32s2 --manifest-files ${MANIFEST_FILE} --manifest-rootpath ${IDF_PATH}
+          idf-build-apps build -p ${EXAMPLES_PATH} -t esp32s2 --manifest-files ${MANIFEST_FILE} --manifest-rootpath ${IDF_PATH}
       - name: Build USB Device examples
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          export EXAMPLES_PATH="${IDF_PATH}/examples/peripherals/usb/device"
-          export MANIFEST_FILE="${IDF_PATH}/examples/peripherals/.build-test-rules.yml"
-          python .github/ci/override_managed_component.py tinyusb . ${EXAMPLES_PATH}/tusb_*
-          idf-build-apps find --path ${EXAMPLES_PATH}/ --recursive --target esp32s2 --manifest-file ${MANIFEST_FILE}
-          idf-build-apps build --path ${EXAMPLES_PATH}/ --recursive --target esp32s2 --manifest-file ${MANIFEST_FILE}
+          python .github/ci/override_managed_component.py tinyusb . ${IDF_PATH}/examples/peripherals/usb/device/tusb_*
+          idf-build-apps find --config-file ${CONFIG_PATH} --manifest-rootpath ${IDF_PATH}
+          idf-build-apps build --config-file ${CONFIG_PATH} --manifest-rootpath ${IDF_PATH}
       - uses: actions/upload-artifact@v4
+        env:
+          IDF_ROOT: "/opt/esp/idf"
         with:
-          # We upload only the USB Device example binaries to run them on the target
-          name: usb_device_tusb_apps_bin_${{ matrix.idf_ver }}
+          # We upload only USB Device example binaries to run them on the target
+          name: usb_device_examples_bin_${{ matrix.idf_ver }}
           path: |
-              /opt/esp/idf/examples/peripherals/usb/device/tusb_*/build/bootloader/bootloader.bin
-              /opt/esp/idf/examples/peripherals/usb/device/tusb_*/build/partition_table/partition-table.bin
-              /opt/esp/idf/examples/peripherals/usb/device/tusb_*/build/tusb_*.bin
-              /opt/esp/idf/examples/peripherals/usb/device/tusb_*/build/tusb_*.elf
-              /opt/esp/idf/examples/peripherals/usb/device/tusb_*/build/flasher_args.json
-              /opt/esp/idf/examples/peripherals/usb/device/tusb_*/build/config/sdkconfig.json
+              ${{ env.IDF_ROOT }}/**/build_esp*/bootloader/bootloader.bin
+              ${{ env.IDF_ROOT }}/**/build_esp*/partition_table/partition-table.bin
+              ${{ env.IDF_ROOT }}/**/build_esp*/tusb_*.bin
+              ${{ env.IDF_ROOT }}/**/build_esp*/tusb_*.elf
+              ${{ env.IDF_ROOT }}/**/build_esp*/flasher_args.json
+              ${{ env.IDF_ROOT }}/**/build_esp*/config/sdkconfig.json
           if-no-files-found: error
   run-target:
-    name: Run USB Device examples
+    name: Run
+    # Disable the job in forks
     if: ${{ github.repository_owner == 'espressif' }}
     needs: build
     strategy:
       fail-fast: false
       matrix:
+        # Run esp-idf examples, starting from v5.3
         idf_ver: ["release-v5.3", "release-v5.4", "release-v5.5" , "latest"]
         idf_target: ["esp32s2"]
         runner_tag: ["usb_device"]
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}"]
     container:
+      # We run on espressif/idf image as we need the code of examples to be present to run pytest
       image: espressif/idf:${{ matrix.idf_ver }}
       options: --privileged --device-cgroup-rule="c 188:* rmw" --device-cgroup-rule="c 166:* rmw"
+    env:
+      # We do not use ${IDF_PATH} here, because it is not available during download of artifacts step
+      IDF_ROOT: "/opt/esp/idf"
+      IDF_EXAMPLES_PATH: "${IDF_PATH}/examples/peripherals/usb/device"
     steps:
       - name: ⚙️ Install System tools
         run: |
@@ -71,16 +85,15 @@ jobs:
         env:
           PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"
         run: |
-          cd ${IDF_PATH}
-          . ./export.sh
+          . ${IDF_PATH}/export.sh
           pip install --no-cache-dir --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-jtag pytest-embedded-idf pyserial pyusb python-gitlab minio idf-build-apps idf_ci pytest_ignore_test_results pytest-timeout netifaces
       - uses: actions/download-artifact@v4
         with:
-          name: usb_device_tusb_apps_bin_${{ matrix.idf_ver }}
-          path: /opt/esp/idf/examples/peripherals/usb/device
-      - name: Run USB Test App on target
+          # Need to set the path manually.
+          # The examples were built on a system files, which are not under the repository.
+          name: usb_device_examples_bin_${{ matrix.idf_ver }}
+          path: ${{ env.IDF_ROOT }}
+      - name: Run on target
         run: |
-          cd ${IDF_PATH}
-          . ./export.sh
-          export EXAMPLES_PATH="${IDF_PATH}/examples/peripherals/usb/device"
-          pytest ${EXAMPLES_PATH} --target ${{ matrix.idf_target }} -m ${{ matrix.runner_tag }} --ignore-result-cases=*ncm_example
+          . ${IDF_PATH}/export.sh
+          pytest ${{ env.IDF_EXAMPLES_PATH }} --target ${{ matrix.idf_target }} -m ${{ matrix.runner_tag }} --ignore-result-cases=*ncm_example --build-dir=build_${{ matrix.idf_target }}

--- a/.github/workflows/build_iot_examples.yml
+++ b/.github/workflows/build_iot_examples.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    name: Build
     strategy:
       matrix:
         idf_ver: ["release-v5.3", "release-v5.4", "release-v5.5", "latest"]
@@ -13,9 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     env:
-      ESP_IOT_PATH: esp-iot-solution
-      MANIFEST_PATH: esp-iot-solution/examples/.build-rules.yml
-      EXAMPLE_PATH: esp-iot-solution/examples/usb/device/${{ matrix.name }}
+      IDF_COMP_MAN_VER: "2.4.3"
+      IDF_BUILD_APPS_VER: "2.13.1"
+      TARGET_PATH: esp-iot-solution
+      TARGET_MANIFEST_PATH: esp-iot-solution/examples/.build-rules.yml
+      TARGET_EXAMPLES_PATH: esp-iot-solution/examples/usb/device/${{ matrix.name }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -27,7 +30,7 @@ jobs:
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install --no-cache-dir idf-component-manager>=2.1.2 idf-build-apps==2.4.3 pyyaml --upgrade
-          python .github/ci/override_managed_component.py tinyusb . ${{ env.EXAMPLE_PATH }}/
-          idf-build-apps find --paths ${{ env.EXAMPLE_PATH }} --target all --manifest-file ${{ env.MANIFEST_PATH }} --manifest-rootpath ${{ env.ESP_IOT_PATH }}
-          idf-build-apps build --paths ${{ env.EXAMPLE_PATH }} --target all --manifest-file ${{ env.MANIFEST_PATH }} --manifest-rootpath ${{ env.ESP_IOT_PATH }}
+          pip install --no-cache-dir idf-component-manager>=${{ env.IDF_COMP_MAN_VER }} idf-build-apps==${{ env.IDF_BUILD_APPS_VER }} pyyaml --upgrade
+          python .github/ci/override_managed_component.py tinyusb . ${{ env.TARGET_EXAMPLES_PATH }}/
+          idf-build-apps find -p ${{ env.TARGET_EXAMPLES_PATH }} -t all --manifest-file ${{ env.TARGET_MANIFEST_PATH }} --manifest-rootpath ${{ env.TARGET_PATH }}
+          idf-build-apps build -p ${{ env.TARGET_EXAMPLES_PATH }} -t all --manifest-file ${{ env.TARGET_MANIFEST_PATH }} --manifest-rootpath ${{ env.TARGET_PATH }}


### PR DESCRIPTION
Fix and extension for previously added CI workflows:

- https://github.com/espressif/tinyusb/pull/58
- https://github.com/espressif/tinyusb/pull/42

## Common
- Version of tools (`idf-component-manager` and `idf-build-apps`) as environment variables `IDF_COMP_MAN_VER` and `IDF_BUILD_APPS_VER` to simplify the version update procedure in the future.

Tools might be updated, so to decrease the time of searching the necessary value in the workflow code, they moved to `env.`

## ESP-USB Test Apps - Build & Run
- Build for all supported targets, not only for esp32s2. Run only on esp32s2

## ESP-IDF USB Device examples - Build & Run
- Build for all supported targets, not only for esp32s2. Run only on esp32s2. 
- Use local idf-build-apps configuration file (`.github/ci/.build_and_run_idf_examples_config.toml`), to exclude unnecessary examples (e.g. cherryusb) and configure the idf-build-apps. 

## ESP-IDF Network example (sta2eth) - Build 
- Fix override tinyusb component