### PR TITLE
feature(ci): Adding esp32p4 target to Run step [v0.18]

### DIFF
--- a/.github/workflows/build_and_run_esp_usb_test_apps.yml
+++ b/.github/workflows/build_and_run_esp_usb_test_apps.yml
@@ -65,9 +65,15 @@ jobs:
       fail-fast: false
       matrix:
         idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "latest"]
-        idf_target: ["esp32s2"]
+        idf_target: ["esp32s2", "esp32p4"]
         sdkconfig: ["default"]
         runner_tag: ["usb_device"]
+        exclude:
+          # Exclude esp32p4 for releases before IDF 5.3 for all runner tags (esp32p4 support starts in IDF 5.3)
+          - idf_ver: "release-v5.1"
+            idf_target: "esp32p4"
+          - idf_ver: "release-v5.2"
+            idf_target: "esp32p4"
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}"]
     container:
       image: python:3.11-bookworm

--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -63,10 +63,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Run esp-idf examples, starting from v5.3
-        idf_ver: ["release-v5.3", "release-v5.4", "release-v5.5" , "latest"]
-        idf_target: ["esp32s2"]
+        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5" , "latest"]
+        idf_target: ["esp32s2", "esp32p4"]
         runner_tag: ["usb_device"]
+        exclude:
+          # Exclude esp32p4 for releases before IDF 5.3 for all runner tags (esp32p4 support starts in IDF 5.3)
+          - idf_ver: "release-v5.1"
+            idf_target: "esp32p4"
+          - idf_ver: "release-v5.2"
+            idf_target: "esp32p4"
     runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}"]
     container:
       # We run on espressif/idf image as we need the code of examples to be present to run pytest


### PR DESCRIPTION
Duplicate: https://github.com/espressif/tinyusb/pull/62 to master, as it was merged to the f`ix/override_tinyusb_in_network_branch`. 
