### PR TITLE
feature(ci): Updated CI workflows [v0.18]

### DIFF
--- a/.github/ci/.build_and_run_idf_examples_config.toml
+++ b/.github/ci/.build_and_run_idf_examples_config.toml
@@ -17,6 +17,7 @@ recursive = true
 manifest_file = "${IDF_PATH}/examples/peripherals/.build-test-rules.yml"
 check_warnings = true
 target = "all"
+enable_preview_targets = true
 
 # Build related options (build_dir uses '@t' for target and '@w' for wildcard pattern (sdkconfig usually)
 build_dir = "build_@t_@w"

--- a/.github/workflows/build_and_run_esp_usb_test_apps.yml
+++ b/.github/workflows/build_and_run_esp_usb_test_apps.yml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "latest"]
+        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "latest"]
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     env:
       IDF_COMP_MAN_VER: "2.4.3"
-      IDF_BUILD_APPS_VER: "2.13.1"
+      IDF_BUILD_APPS_VER: "2.13.3"
       # We are cloning esp-usb repo to get the test apps to build, the paths should be configured explicitly
       ESP_USB_PATH: esp-usb
       ESP_USB_CONFIG_FILE: esp-usb/.idf_build_apps.toml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "latest"]
+        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "latest"]
         idf_target: ["esp32s2", "esp32p4"]
         sdkconfig: ["default"]
         runner_tag: ["usb_device"]

--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -10,12 +10,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "latest"]
+        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "latest"]
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     env:
       IDF_COMP_MAN_VER: "2.4.3"
-      IDF_BUILD_APPS_VER: "2.13.1"
+      IDF_BUILD_APPS_VER: "2.13.3"
       CONFIG_PATH: ${{ github.workspace }}/.github/ci/.build_and_run_idf_examples_config.toml
     steps:
       - uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5" , "latest"]
+        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "latest"]
         idf_target: ["esp32s2", "esp32p4"]
         runner_tag: ["usb_device"]
         exclude:

--- a/.github/workflows/build_iot_examples.yml
+++ b/.github/workflows/build_iot_examples.yml
@@ -9,13 +9,13 @@ jobs:
     name: Build
     strategy:
       matrix:
-        idf_ver: ["release-v5.3", "release-v5.4", "release-v5.5", "latest"]
+        idf_ver: ["release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "latest"]
         name: ["usb_uart_bridge"]
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
     env:
       IDF_COMP_MAN_VER: "2.4.3"
-      IDF_BUILD_APPS_VER: "2.13.1"
+      IDF_BUILD_APPS_VER: "2.13.3"
       TARGET_PATH: esp-iot-solution
       TARGET_MANIFEST_PATH: esp-iot-solution/examples/.build-rules.yml
       TARGET_EXAMPLES_PATH: esp-iot-solution/examples/usb/device/${{ matrix.name }}


### PR DESCRIPTION
## Description
- Added esp-idf release v6.0
- Enabled preview target build to the esp-idf examples (to include ESP32-H4)
- Updated the idf-build-apps version to 2.13.3