### PR TITLE
fix(tusb_debug): Added stdio.h include when CFG_TUSB_DEBUG_PRINTF [WIP]

### DIFF
--- a/src/common/tusb_debug.h
+++ b/src/common/tusb_debug.h
@@ -52,6 +52,7 @@ extern char const* const tu_str_xfer_result[];
 void tu_print_mem(void const *buf, uint32_t count, uint8_t indent);
 
 #ifdef CFG_TUSB_DEBUG_PRINTF
+  #include <stdio.h>
   extern int CFG_TUSB_DEBUG_PRINTF(const char *format, ...);
   #define tu_printf    CFG_TUSB_DEBUG_PRINTF
 #else


### PR DESCRIPTION
## Description

Adding the include in https://github.com/hathach/tinyusb/pull/3326

### Why it works with version 0.19.0? 

- [ ] Was in `tusb_common.h` before. Moved out, for those, who is using the custom implementation of `printf`.