### PR TITLE
feature(dcd_dwc2): Added the dcd_deinit() stub call to avoid assert [WIP]

### DIFF
--- a/src/portable/synopsys/dwc2/dcd_dwc2.c
+++ b/src/portable/synopsys/dwc2/dcd_dwc2.c
@@ -503,6 +503,12 @@ bool dcd_init(uint8_t rhport, const tusb_rhport_init_t* rh_init) {
   return true;
 }
 
+bool dcd_deinit(uint8_t rhport) {
+  (void) rhport;
+  // TODO: stub for the deinit function
+  return true;
+}
+
 void dcd_int_enable(uint8_t rhport) {
   dwc2_dcd_int_enable(rhport);
 }


### PR DESCRIPTION
## Description

We can stub the `dcd_deinit()` for now, as we will configure the port again during the next `dcd_init()` call. 

Implementation can be added later. 
