### PR TITLE
fix(build): Fix cmake warning about freertos component dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,6 @@ set(compile_options
     "-DCFG_TUSB_MCU=${tusb_mcu}"
     )
 
-idf_component_get_property(freertos_include freertos ORIG_INCLUDE_PATH)
-
 set(includes_private
     "src/"
     "src/device"
@@ -28,8 +26,6 @@ set(includes_private
 
 set(includes_public
     "src/"
-    # The FreeRTOS API include convention in tinyusb is different from esp-idf
-    "${freertos_include}"
     )
 
 set(srcs
@@ -72,6 +68,7 @@ idf_component_register(SRCS ${srcs}
                        INCLUDE_DIRS ${includes_public}
                        PRIV_INCLUDE_DIRS ${includes_private}
                        PRIV_REQUIRES  ${requirements_private}
+                       REQUIRES freertos
                        )
 
 target_compile_options(${COMPONENT_LIB} PUBLIC ${compile_options})


### PR DESCRIPTION
### Description

Removing CMake warning:

```sh
CMake Warning at /home/peter/esp/esp-idf/tools/cmake/component_validation.cmake:86 (message):
  Include directory
  '/home/peter/esp/esp-idf/components/freertos/FreeRTOS-Kernel/include/freertos'
  belongs to component freertos but is being used by component tinyusb.  It
  is recommended to define the component dependency for 'tinyusb' on the
  component freertos, i.e.  'idf_component_register(...  REQUIRES freertos)'
  in the CMakeLists.txt of tinyusb, and specify the included directory as
  idf_component_register(...  INCLUDE_DIRS <dir relative to component>) in
  the CMakeLists.txt of component freertos.
Call Stack (most recent call first):
  /home/peter/esp/esp-idf/tools/cmake/component_validation.cmake:130 (__component_validation_check_include_dirs)
  /home/peter/esp/esp-idf/CMakeLists.txt:353 (__component_validation_run_checks)
  ```
  
- TinyUSB's CMake adds FreeRTOS's private include path via `ORIG_INCLUDE_PATH` instead of declaring a component dependency. 
- ESP-IDF's TinyUSB port uses `CFG_TUSB_OS_INC_PATH_DEFAULT` of `freertos/`, so freertos/FreeRTOS.h resolves through the freertos component's public INCLUDE_DIRS. 
- Removing the duplicate path and adding REQUIRES freertos

### Related

- Closes espressif/esp-idf#18436
- Blocked by #78 
