### PR TITLE
fix(ci): Fix CI build and run

### DIFF
--- a/.github/ci/.build_and_run_idf_examples_config.toml
+++ b/.github/ci/.build_and_run_idf_examples_config.toml
@@ -6,18 +6,25 @@
 # Run step in the workflow, as it will need to reference the new build directory.
 
 paths = [
-    "${IDF_PATH}/examples/peripherals/usb/device",     # ESP-IDF USB Device examples path
+    "examples/peripherals/usb/device",     # ESP-IDF USB Device examples path
 ]
 
+# Exclude cherryusb-based device examples
 exclude = [
-    "${IDF_PATH}/examples/peripherals/usb/device/cherryusb_serial_device", # Exclude cherryusb-based device examples
+    "examples/peripherals/usb/device/cherryusb_serial_device",
 ]
 
 recursive = true
-manifest_file = "${IDF_PATH}/examples/peripherals/.build-test-rules.yml"
 check_warnings = true
 target = "all"
 enable_preview_targets = true
 
 # Build related options (build_dir uses '@t' for target and '@w' for wildcard pattern (sdkconfig usually)
 build_dir = "build_@t_@w"
+
+# config rules
+config_rules = [
+    'sdkconfig.ci=default',
+    'sdkconfig.ci.*=',
+    '=default',
+]

--- a/.github/ci/.idf-build-examples-rules.yml
+++ b/.github/ci/.idf-build-examples-rules.yml
@@ -1,0 +1,9 @@
+# Manifest file for build_and_run_idf_examples.yml CI workflow
+
+examples/peripherals/usb/device:
+  disable:
+    - if: SOC_USB_OTG_SUPPORTED != 1
+
+examples/peripherals/usb/device/tusb_ncm:
+  disable:
+    - if: SOC_USB_OTG_SUPPORTED != 1 or SOC_WIFI_SUPPORTED != 1

--- a/.github/workflows/build_and_run_esp_usb_test_apps.yml
+++ b/.github/workflows/build_and_run_esp_usb_test_apps.yml
@@ -8,17 +8,23 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+# Cancel previous runs of this workflow for the same PR when a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "latest"]
+        idf_ver: ["release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "latest"]
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
+    permissions:
+      pull-requests: read
     env:
-      IDF_COMP_MAN_VER: "2.4.3"
       IDF_BUILD_APPS_VER: "2.13.3"
       # We are cloning esp-usb repo to get the test apps to build, the paths should be configured explicitly
       ESP_USB_PATH: esp-usb
@@ -27,7 +33,7 @@ jobs:
       ESP_USB_IGNORE_WARNING_FILE: esp-usb/.ignore_build_warnings.txt
       ESP_TINYUSB_TEST_APPS: esp-usb/device/esp_tinyusb/test_apps
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - name: Clone esp-usb repository
@@ -37,14 +43,14 @@ jobs:
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install --no-cache-dir idf-component-manager>=${{ env.IDF_COMP_MAN_VER }} idf-build-apps==${{ env.IDF_BUILD_APPS_VER }} pyyaml --upgrade
+          pip install --no-cache-dir idf-build-apps==${{ env.IDF_BUILD_APPS_VER }} pyyaml --upgrade
           export PEDANTIC_FLAGS="-DIDF_CI_BUILD -Werror -Werror=deprecated-declarations -Werror=unused-variable -Werror=unused-but-set-variable -Werror=unused-function"
           export EXTRA_CFLAGS="${PEDANTIC_FLAGS} -Wstrict-prototypes"
           export EXTRA_CXXFLAGS="${PEDANTIC_FLAGS}"
           python .github/ci/override_managed_component.py tinyusb . ${{ env.ESP_TINYUSB_TEST_APPS }}/*/
           idf-build-apps find --config-file ${{ env.ESP_USB_CONFIG_FILE }} -p ${{ env.ESP_TINYUSB_TEST_APPS }} -t all --manifest-files ${{ env.ESP_USB_MANIFEST }} --manifest-rootpath ${{ env.ESP_USB_PATH }}
           idf-build-apps build --config-file ${{ env.ESP_USB_CONFIG_FILE }} -p ${{ env.ESP_TINYUSB_TEST_APPS }} -t all --manifest-files ${{ env.ESP_USB_MANIFEST }} --manifest-rootpath ${{ env.ESP_USB_PATH }} --ignore-warning-files ${{ env.ESP_USB_IGNORE_WARNING_FILE }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           # Test apps builds live under the repository workspace, we use workspace-relative glob
           name: usb_device_test_app_bin_${{ matrix.idf_ver }}
@@ -65,25 +71,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "latest"]
+        idf_ver: ["release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "latest"]
         idf_target: ["esp32s2", "esp32p4"]
         sdkconfig: ["default"]
         runner_tag: ["usb_device"]
+        eco_ver: ["eco_default", "eco4"]
         exclude:
           # Exclude esp32p4 for releases before IDF 5.3 for all runner tags (esp32p4 support starts in IDF 5.3)
-          - idf_ver: "release-v5.1"
-            idf_target: "esp32p4"
           - idf_ver: "release-v5.2"
             idf_target: "esp32p4"
-    runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}"]
+          # Exclude eco4 version for esp32s2
+          - idf_target: "esp32s2"
+            eco_ver: "eco4"
+          # esp32p4 ECO6 support starts in IDF 5.5
+          - idf_target: "esp32p4"
+            eco_ver: "eco_default"
+            idf_ver: "release-v5.4"
+          - idf_target: "esp32p4"
+            eco_ver: "eco_default"
+            idf_ver: "release-v5.3"
+    runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}", "${{ matrix.eco_ver }}"]
     container:
       image: python:3.11-bookworm
       options: --privileged --device-cgroup-rule="c 188:* rmw" --device-cgroup-rule="c 166:* rmw"
+      volumes:
+        - /dev/bus/usb:/dev/bus/usb
     env:
       ESP_USB_ROOT: esp-usb
       ESP_USB_TEST_APPS_PATH: esp-usb/device/esp_tinyusb/test_apps
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Clone esp-usb repository
         run: |
           git clone https://github.com/espressif/esp-usb.git
@@ -94,12 +111,26 @@ jobs:
       - name: Install Python packages
         env:
           PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"
-        run: pip install --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf pyserial pyusb
-      - uses: actions/download-artifact@v4
+        run: pip install --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf pyserial pyusb pytest-rerunfailures idf-ci
+      - uses: actions/download-artifact@v7
         with:
           # No need to set the path manually.
           # The test apps were built after cloning the esp-usb repo,
           # and the build artifacts already have the correct folder structure.
           name: usb_device_test_app_bin_${{ matrix.idf_ver }}
       - name: Run on target
-        run: pytest ${{ env.ESP_USB_TEST_APPS_PATH }} --target=${{ matrix.idf_target }} -m ${{ matrix.runner_tag }} --build-dir=build_${{ matrix.idf_target }}_${{ matrix.sdkconfig }}
+        run: |
+
+          # Set runner marker argument
+          MARKER_ARG="-m=${{ matrix.runner_tag }}"
+
+          if [ "${{ matrix.idf_target }}" = "esp32p4" ]; then
+            if [ "${{ matrix.eco_ver }}" = "eco_default" ]; then
+              MARKER_ARG="$MARKER_ARG and ${{ matrix.eco_ver }}"
+            else
+              MARKER_ARG="$MARKER_ARG and ${{ matrix.idf_target }}_${{ matrix.eco_ver }}"
+            fi
+          fi
+
+          echo "Running pytest with marker: $MARKER_ARG"
+          pytest ${{ env.ESP_USB_TEST_APPS_PATH }} --target=${{ matrix.idf_target }} "$MARKER_ARG" --build-dir=build_${{ matrix.idf_target }}_

--- a/.github/workflows/build_and_run_idf_examples.yml
+++ b/.github/workflows/build_and_run_idf_examples.yml
@@ -4,26 +4,33 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+# Cancel previous runs of this workflow for the same PR when a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "latest"]
+        idf_ver: ["release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "latest"]
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
+    permissions:
+      pull-requests: read
     env:
-      IDF_COMP_MAN_VER: "2.4.3"
       IDF_BUILD_APPS_VER: "2.13.3"
       CONFIG_PATH: ${{ github.workspace }}/.github/ci/.build_and_run_idf_examples_config.toml
+      MANIFEST_PATH: ${{ github.workspace }}/.github/ci/.idf-build-examples-rules.yml
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Python dependencies
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install --no-cache-dir idf-component-manager>=${{ env.IDF_COMP_MAN_VER }} idf-build-apps==${{ env.IDF_BUILD_APPS_VER }} pyyaml --upgrade
+          pip install --no-cache-dir idf-build-apps==${{ env.IDF_BUILD_APPS_VER }} pyyaml --upgrade
       - name: Build Network USB related examples
         shell: bash
         run: |
@@ -39,9 +46,10 @@ jobs:
         run: |
           . ${IDF_PATH}/export.sh
           python .github/ci/override_managed_component.py tinyusb . ${IDF_PATH}/examples/peripherals/usb/device/tusb_*
-          idf-build-apps find --config-file ${CONFIG_PATH} --manifest-rootpath ${IDF_PATH}
-          idf-build-apps build --config-file ${CONFIG_PATH} --manifest-rootpath ${IDF_PATH}
-      - uses: actions/upload-artifact@v4
+          cd ${IDF_PATH}
+          idf-build-apps find --config-file ${CONFIG_PATH} --manifest-file ${MANIFEST_PATH}
+          idf-build-apps build --config-file ${CONFIG_PATH} --manifest-file ${MANIFEST_PATH}
+      - uses: actions/upload-artifact@v6
         env:
           IDF_ROOT: "/opt/esp/idf"
         with:
@@ -63,19 +71,41 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_ver: ["release-v5.1", "release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "latest"]
+        idf_ver: ["release-v5.2", "release-v5.3", "release-v5.4", "release-v5.5", "release-v6.0", "latest"]
         idf_target: ["esp32s2", "esp32p4"]
         runner_tag: ["usb_device"]
+        eco_ver: ["eco_default", "eco4"]
         exclude:
           # Exclude all "latest" runs for esp32p4 till the transition to ECO5 will be done
           - idf_ver: "latest"
             idf_target: "esp32p4"
           # Exclude esp32p4 for releases before IDF 5.3 for all runner tags (esp32p4 support starts in IDF 5.3)
-          - idf_ver: "release-v5.1"
-            idf_target: "esp32p4"
           - idf_ver: "release-v5.2"
             idf_target: "esp32p4"
-    runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}"]
+          # Exclude eco4 version for esp32s2
+          - idf_target: "esp32s2"
+            eco_ver: "eco4"
+          # Exclude eco_default for older IDF versions, esp32p4 ECO6 support starts in IDF 5.5
+          - idf_target: "esp32p4"
+            eco_ver: "eco_default"
+            idf_ver: "release-v5.2"
+          - idf_target: "esp32p4"
+            eco_ver: "eco_default"
+            idf_ver: "release-v5.3"
+          - idf_target: "esp32p4"
+            eco_ver: "eco_default"
+            idf_ver: "release-v5.4"
+          # Exclude eco4 for newer IDF versions, esp32p4 ECO6 is default in IDF 5.5 and later
+          - idf_target: "esp32p4"
+            eco_ver: "eco4"
+            idf_ver: "release-v5.5"
+          - idf_target: "esp32p4"
+            eco_ver: "eco4"
+            idf_ver: "release-v6.0"
+          - idf_target: "esp32p4"
+            eco_ver: "eco4"
+            idf_ver: "latest"
+    runs-on: [self-hosted, linux, docker, "${{ matrix.idf_target }}", "${{ matrix.runner_tag }}", "${{ matrix.eco_ver }}"]
     container:
       # We run on espressif/idf image as we need the code of examples to be present to run pytest
       image: espressif/idf:${{ matrix.idf_ver }}
@@ -94,8 +124,8 @@ jobs:
           PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"
         run: |
           . ${IDF_PATH}/export.sh
-          pip install --no-cache-dir --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-jtag pytest-embedded-idf pyserial pyusb python-gitlab minio idf-build-apps idf_ci pytest_ignore_test_results pytest-timeout netifaces
-      - uses: actions/download-artifact@v4
+          pip install --no-cache-dir --only-binary cryptography pytest-embedded pytest-embedded-serial-esp pytest-embedded-idf pyserial pyusb idf-ci pytest-ignore-test-results pytest-timeout netifaces
+      - uses: actions/download-artifact@v7
         with:
           # Need to set the path manually.
           # The examples were built on a system files, which are not under the repository.

--- a/.github/workflows/build_iot_examples.yml
+++ b/.github/workflows/build_iot_examples.yml
@@ -13,14 +13,15 @@ jobs:
         name: ["usb_uart_bridge"]
     runs-on: ubuntu-latest
     container: espressif/idf:${{ matrix.idf_ver }}
+    permissions:
+      pull-requests: read
     env:
-      IDF_COMP_MAN_VER: "2.4.3"
       IDF_BUILD_APPS_VER: "2.13.3"
       TARGET_PATH: esp-iot-solution
       TARGET_MANIFEST_PATH: esp-iot-solution/examples/.build-rules.yml
       TARGET_EXAMPLES_PATH: esp-iot-solution/examples/usb/device/${{ matrix.name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - name: Clone esp-iot-solution repository
@@ -30,7 +31,7 @@ jobs:
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
-          pip install --no-cache-dir idf-component-manager>=${{ env.IDF_COMP_MAN_VER }} idf-build-apps==${{ env.IDF_BUILD_APPS_VER }} pyyaml --upgrade
+          pip install --no-cache-dir idf-build-apps==${{ env.IDF_BUILD_APPS_VER }} pyyaml --upgrade
           python .github/ci/override_managed_component.py tinyusb . ${{ env.TARGET_EXAMPLES_PATH }}/
           idf-build-apps find -p ${{ env.TARGET_EXAMPLES_PATH }} -t all --manifest-file ${{ env.TARGET_MANIFEST_PATH }} --manifest-rootpath ${{ env.TARGET_PATH }}
           idf-build-apps build -p ${{ env.TARGET_EXAMPLES_PATH }} -t all --manifest-file ${{ env.TARGET_MANIFEST_PATH }} --manifest-rootpath ${{ env.TARGET_PATH }}

--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -10,7 +10,7 @@ jobs:
   upload_components:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Upload components to component service
         uses: espressif/upload-components-ci-action@v2


### PR DESCRIPTION
Fixing CI workflows:

- idf examples build
- iot examples build
- test apps build

### Changes
- removed IDF 5.1 from CI build and run
- added multiple sdkconfig build for idf examples
- started using separate mainfest file for idf examples build
- added read permissions
- added esp32p4 ECO4, ECO6 build and target runner setup into the workflow
- updated github actions versions
